### PR TITLE
Fixed popup highlight color

### DIFF
--- a/themes/vercel-theme.json
+++ b/themes/vercel-theme.json
@@ -144,7 +144,11 @@
         "warning": "#ff9907",
         "warning.background": "#ff990733",
         "warning.border": "#ff9907",
-        "players": [],
+        "players": [
+          {
+            "selection": "#52a8ff33"
+          }
+        ],
         "syntax": {
           "property": {
             "color": "#52a8ff",
@@ -452,7 +456,11 @@
         "warning": "#A35200",
         "warning.background": "#A3520033",
         "warning.border": "#A35200",
-        "players": [],
+        "players": [
+          {
+            "selection": "#0068d633"
+          }
+        ],
         "syntax": {
           "property": {
             "color": "#0068d6",


### PR DESCRIPTION
fix #7 

## Vercel Dark
<img width="243" alt="image" src="https://github.com/user-attachments/assets/c7be5055-afe7-460e-a2f3-1e280c01969c" />

## Vercel Light
<img width="240" alt="image" src="https://github.com/user-attachments/assets/20ce44e4-57b8-4cf1-aad4-af49a8405928" />
